### PR TITLE
add draft of getProfileInfo

### DIFF
--- a/controllers/authControllers.js
+++ b/controllers/authControllers.js
@@ -101,10 +101,23 @@ const updateAvatar = async (req, res, next) => {
   }
 };
 
+const getProfileInfo = async (req, res) => {
+  const { id } = req.params;
+  const user = await authServices.findUserById(id);
+  res.json({
+    name: user.name,
+    email: user.email,
+    avatar: user.avatar,
+    followers: user.followers,
+    following: user.following,
+  });
+};
+
 export default {
   signup: ctrlWraper(signup),
   signin: ctrlWraper(signin),
   logout: ctrlWraper(logout),
   getCurrent: ctrlWraper(getCurrent),
   updateAvatar: ctrlWraper(updateAvatar),
+  getProfileInfo: ctrlWraper(getProfileInfo),
 };

--- a/routes/authRouter.js
+++ b/routes/authRouter.js
@@ -34,4 +34,6 @@ authRouter.patch(
   ctrlUser.updateAvatar
 );
 
+authRouter.get('/profile/:id', authenticate, ctrlUser.getProfileInfo);
+
 export default authRouter;


### PR DESCRIPTION
Add a draft endpoint to get user profile information. The response contains an object with: name, email, avatar, followers, following.
The response object is missing the number of recipes created and the number of favorite recipes. The reason is there is no data source.